### PR TITLE
Use GitHub Actions CI to test Windows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          #- {os: windows-latest, r: 'release', rust-version: 'stable'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable'}
           #- {os: macOS-latest,   r: 'release', rust-version: 'stable'}
           - {os: ubuntu-20.04,    r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           #- {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
@@ -33,6 +33,13 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.config.rust-version }}
+          override: true
+
+      - name: Add Rtools targets to Rust
+        if: runner.os == 'Windows'
+        run: |
+          rustup target add i686-pc-windows-gnu
+          rustup target add x86_64-pc-windows-gnu
 
       - uses: r-lib/actions/setup-r@v1
         with:


### PR DESCRIPTION
(c.f. https://github.com/clauswilke/sinab/issues/13#issuecomment-736623350)

While AppVeyor build fails, GitHub Actions CI works for Windows. This pull request adds an Windows runner to the current `R-CMD-check.yaml` based on the instruction by [hellorust's README](https://github.com/r-rust/hellorust/#github-actions)